### PR TITLE
Add frame toggle, categories menu, and centered clock

### DIFF
--- a/Basq/Basq/ContentView.swift
+++ b/Basq/Basq/ContentView.swift
@@ -8,14 +8,20 @@
 import SwiftUI
 
 /// Root view for the tvOS application. Displays a remote image whose
-/// filename increments every minute and optionally shows a clock in the
-/// bottom-right corner.
+/// filename increments every minute and optionally shows a large clock
+/// centered on the screen.
 struct ContentView: View {
     /// Starting index for the image name.
     @State private var currentImageNumber: Int = 3189
 
     /// Controls whether the clock is visible.
     @State private var showClock: Bool = false
+
+    /// Controls whether the image is wrapped in an art frame.
+    @State private var showFrame: Bool = false
+
+    /// Displays the selected category of images.
+    @State private var selectedCategoryName: String = "Art"
 
     /// The current date used for the clock display.
     @State private var currentDate: Date = Date()
@@ -25,6 +31,13 @@ struct ContentView: View {
 
     /// A timer that fires every second to update the clock text.
     private let clockTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    /// Available image categories mapped to their path component.
+    private let categories: [String: String] = [
+        "Art": "art",
+        "Nature": "nature",
+        "Abstract": "abstract"
+    ]
 
     var body: some View {
         ZStack {
@@ -37,6 +50,7 @@ struct ContentView: View {
                     image
                         .resizable()
                         .scaledToFit()
+                        .artFrame(showFrame)
                 case .failure:
                     Image(systemName: "xmark.octagon")
                         .resizable()
@@ -50,31 +64,40 @@ struct ContentView: View {
                 currentImageNumber += 1
             }
 
-            // Overlay containing the toggle button and optional clock.
+            // Large clock centered on the screen.
+            if showClock {
+                Text(timeString)
+                    .font(.system(size: 150, weight: .bold, design: .monospaced))
+                    .padding()
+                    .background(Color.black.opacity(0.7))
+                    .foregroundColor(.white)
+                    .cornerRadius(12)
+                    .onReceive(clockTimer) { date in
+                        currentDate = date
+                    }
+            }
+
+            // Overlay containing control buttons.
             VStack {
                 HStack {
                     Button(showClock ? "Hide Clock" : "Show Clock") {
                         showClock.toggle()
                     }
-                    .padding()
-                    Spacer()
-                }
-                Spacer()
-                if showClock {
-                    HStack {
-                        Spacer()
-                        Text(timeString)
-                            .font(.title2)
-                            .padding()
-                            .background(Color.black.opacity(0.7))
-                            .foregroundColor(.white)
-                            .cornerRadius(8)
-                            .onReceive(clockTimer) { date in
-                                currentDate = date
-                            }
+                    Button(showFrame ? "Hide Frame" : "Show Frame") {
+                        showFrame.toggle()
                     }
-                    .padding()
+                    Spacer()
+                    Menu(selectedCategoryName) {
+                        ForEach(categories.keys.sorted(), id: \.self) { name in
+                            Button(name) {
+                                selectedCategoryName = name
+                                currentImageNumber = 3189
+                            }
+                        }
+                    }
                 }
+                .padding()
+                Spacer()
             }
         }
         .edgesIgnoringSafeArea(.all)
@@ -82,7 +105,12 @@ struct ContentView: View {
 
     /// Constructs the full URL for the current image number.
     private var imageURL: URL? {
-        URL(string: "https://www.paynebrain.com/art/IMG_\(currentImageNumber).JPG")
+        URL(string: "https://www.paynebrain.com/\(selectedCategoryPath)/IMG_\(currentImageNumber).JPG")
+    }
+
+    /// Resolves the currently selected category into its path component.
+    private var selectedCategoryPath: String {
+        categories[selectedCategoryName] ?? "art"
     }
 
     /// Formats the current date into a human-readable time string.
@@ -90,6 +118,30 @@ struct ContentView: View {
         let formatter = DateFormatter()
         formatter.timeStyle = .medium
         return formatter.string(from: currentDate)
+    }
+}
+
+/// View modifier that applies a simple black frame with a white inset.
+private struct ArtFrame: ViewModifier {
+    let enabled: Bool
+
+    func body(content: Content) -> some View {
+        if enabled {
+            content
+                .padding(20)
+                .background(Color.white)
+                .padding(40)
+                .background(Color.black)
+        } else {
+            content
+        }
+    }
+}
+
+private extension View {
+    /// Conditionally wraps the view in the custom art frame.
+    func artFrame(_ enabled: Bool) -> some View {
+        modifier(ArtFrame(enabled: enabled))
     }
 }
 


### PR DESCRIPTION
## Summary
- allow images to be wrapped in a toggleable black frame with a white inset for depth
- add a categories menu for switching image sources
- enlarge and center the optional clock display

## Testing
- `swift test 2>&1 | head -n 200` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad12fabc8c832b95280a6bcbdf6c42