### PR TITLE
Prevent tvOS dimming when idle

### DIFF
--- a/Basq/Basq/BasqApp.swift
+++ b/Basq/Basq/BasqApp.swift
@@ -6,12 +6,26 @@
 //
 
 import SwiftUI
+import UIKit
 
 @main
 struct BasqApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onAppear {
+                    // Prevent the system from dimming the display or hiding
+                    // controls when the user is idle. This keeps the "Show
+                    // Clock" button visible and the image at full brightness.
+                    UIApplication.shared.isIdleTimerDisabled = true
+                }
+        }
+        .onChange(of: scenePhase) { newPhase in
+            // Re-enable the idle timer when the app is no longer active so
+            // the system can manage power appropriately.
+            UIApplication.shared.isIdleTimerDisabled = (newPhase == .active)
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep "Show Clock" control visible by disabling the idle timer
- automatically re-enable idle timer when app backgrounded

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad65ceab20832b974ac0b0aa18455d