### PR TITLE
Add weather, settings, and park hours

### DIFF
--- a/Basq/Basq/ContentView.swift
+++ b/Basq/Basq/ContentView.swift
@@ -15,6 +15,14 @@ struct ContentView: View {
     // Track button visibility
     @State private var showButton: Bool = true
 
+    // Weather and settings
+    @AppStorage("zipCode") private var zipCode: String = ""
+    @State private var weather: Weather?
+    @State private var showSettings: Bool = false
+
+    // Magic Kingdom hours
+    @State private var magicHours: String = "Loading hours..."
+
     private let minuteTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
     private let clockTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -55,7 +63,29 @@ struct ContentView: View {
                     .animation(.easeInOut(duration: 1), value: showButton)
 
                     Spacer()
+
+                    if let weather {
+                        VStack(alignment: .trailing) {
+                            Text("Temp: \(Int(weather.temperature))°F")
+                            Text("Humidity: \(Int(weather.humidity))%")
+                        }
+                        .font(.caption)
+                        .padding(8)
+                        .background(Color.black.opacity(0.7))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                    }
                 }
+
+                Spacer()
+
+                // Center magic hours
+                Text(magicHours)
+                    .font(.headline)
+                    .padding()
+                    .background(Color.black.opacity(0.7))
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
 
                 Spacer()
 
@@ -68,9 +98,11 @@ struct ContentView: View {
                             .background(Color.black.opacity(0.7))
                             .foregroundColor(.white)
                             .cornerRadius(8)
+                    }
 
-                        Spacer()
+                    Spacer()
 
+                    if showClock {
                         // Bottom-right clock
                         Text(timeString)
                             .font(.title2)
@@ -82,11 +114,33 @@ struct ContentView: View {
                                 currentDate = date
                             }
                     }
+
+                    Button(action: {
+                        showSettings = true
+                        resetButtonFade()
+                    }) {
+                        Image(systemName: "gearshape.fill")
+                            .padding()
+                            .background(Color.black.opacity(0.7))
+                            .foregroundColor(.white)
+                            .cornerRadius(8)
+                    }
+                    .opacity(showButton ? 1 : 0.01)
+                    .animation(.easeInOut(duration: 1), value: showButton)
+                    .sheet(isPresented: $showSettings) {
+                        SettingsView(zipCode: $zipCode) {
+                            Task { await loadWeather() }
+                        }
+                    }
                 }
                 .padding()
             }
         }
         .edgesIgnoringSafeArea(.all)
+        .task {
+            await loadWeather()
+            await loadMagicHours()
+        }
         .onAppear {
             UIApplication.shared.isIdleTimerDisabled = true
             resetButtonFade()
@@ -120,6 +174,27 @@ struct ContentView: View {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         return formatter.string(from: currentDate)
+    }
+
+    // MARK: - Data Loading
+    @MainActor
+    private func loadWeather() async {
+        guard !zipCode.isEmpty else { return }
+        do {
+            weather = try await WeatherService().fetchWeather(zipCode: zipCode)
+        } catch {
+            weather = nil
+        }
+    }
+
+    @MainActor
+    private func loadMagicHours() async {
+        do {
+            let hours = try await MagicHoursService().fetchTodayHours()
+            magicHours = "Magic Kingdom: \(hours.openingTime) - \(hours.closingTime)"
+        } catch {
+            magicHours = "Magic Kingdom hours unavailable"
+        }
     }
 }
 

--- a/Basq/Basq/MagicHoursService.swift
+++ b/Basq/Basq/MagicHoursService.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct ParkHours: Decodable {
+    let openingTime: String
+    let closingTime: String
+}
+
+class MagicHoursService {
+    func fetchTodayHours() async throws -> ParkHours {
+        let url = URL(string: "https://api.themeparks.wiki/v1/parks/walt-disney-world-magic-kingdom/schedules/today")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        struct Response: Decodable {
+            struct Day: Decodable {
+                let openingTime: String?
+                let closingTime: String?
+            }
+            let schedule: [Day]
+        }
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        guard let day = response.schedule.first,
+              let open = day.openingTime,
+              let close = day.closingTime else {
+            throw URLError(.badServerResponse)
+        }
+        return ParkHours(openingTime: open, closingTime: close)
+    }
+}

--- a/Basq/Basq/SettingsView.swift
+++ b/Basq/Basq/SettingsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var zipCode: String
+    var onSave: () -> Void
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Location")) {
+                    TextField("ZIP Code", text: $zipCode)
+                        .keyboardType(.numberPad)
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        onSave()
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView(zipCode: .constant("")) {}
+}

--- a/Basq/Basq/WeatherService.swift
+++ b/Basq/Basq/WeatherService.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct Weather: Decodable {
+    let temperature: Double
+    let humidity: Double
+}
+
+class WeatherService {
+    func fetchWeather(zipCode: String) async throws -> Weather {
+        // Geocode zip code to latitude and longitude
+        let geoURL = URL(string: "https://geocoding-api.open-meteo.com/v1/search?postal_code=\(zipCode)&country=US&format=json")!
+        let (geoData, _) = try await URLSession.shared.data(from: geoURL)
+        struct GeoResponse: Decodable {
+            struct Result: Decodable { let latitude: Double; let longitude: Double }
+            let results: [Result]
+        }
+        let geo = try JSONDecoder().decode(GeoResponse.self, from: geoData)
+        guard let first = geo.results.first else { throw URLError(.badServerResponse) }
+        
+        // Fetch weather using latitude and longitude
+        let weatherURL = URL(string: "https://api.open-meteo.com/v1/forecast?latitude=\(first.latitude)&longitude=\(first.longitude)&current=temperature_2m,relative_humidity_2m&temperature_unit=fahrenheit")!
+        let (weatherData, _) = try await URLSession.shared.data(from: weatherURL)
+        struct WeatherResponse: Decodable {
+            struct Current: Decodable {
+                let temperature_2m: Double
+                let relative_humidity_2m: Double
+            }
+            let current: Current
+        }
+        let response = try JSONDecoder().decode(WeatherResponse.self, from: weatherData)
+        return Weather(temperature: response.current.temperature_2m,
+                       humidity: response.current.relative_humidity_2m)
+    }
+}


### PR DESCRIPTION
## Summary
- Overlay current temperature and humidity in the top-right corner
- Add settings screen for entering ZIP code and refreshing weather
- Show Magic Kingdom park hours in the center of the screen

## Testing
- `swiftc -typecheck Basq/Basq/*.swift` *(fails: no such module 'SwiftUI')*
- `curl https://api.open-meteo.com/v1/forecast?latitude=40&longitude=-73&current=temperature_2m` *(fails: CONNECT tunnel failed, response 403)*
- `curl https://api.themeparks.wiki/v1/parks/walt-disney-world-magic-kingdom/schedules/today` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68afbb18601c832b8ecd646f7bb3762b